### PR TITLE
Fix for: Downloaded files are owned by root:root 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM openjdk:8-jre
 
-MAINTAINER PlusMinus <piddlpiddl@gmail.com>
-
+MAINTAINER mr-bolle
 
 # Create directory, downloader JD" and start JD2 for the initial update and creation of config files.
 RUN \
@@ -9,10 +8,12 @@ RUN \
 	wget -O /opt/JDownloader/JDownloader.jar --user-agent="https://hub.docker.com/r/plusminus/jdownloader2-headless/" --progress=bar:force http://installer.jdownloader.org/JDownloader.jar && \
 	java -Djava.awt.headless=true -jar /opt/JDownloader/JDownloader.jar
 
+# Create a new User into the Container, for the reason to mount the Download Folder into the Host as jdownloader and not as root
+RUN useradd -ms /bin/bash  jdownloader
+WORKDIR /home/jdownloader/Downloads
 
 COPY startJD2.sh /opt/JDownloader/
 RUN chmod +x /opt/JDownloader/startJD2.sh
-
 
 # Run this when the container is started
 CMD /opt/JDownloader/startJD2.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-jre
 
-MAINTAINER mr-bolle
+MAINTAINER PlusMinus <piddlpiddl@gmail.com>
 
 # Create directory, downloader JD" and start JD2 for the initial update and creation of config files.
 RUN \

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # headless-jdownloader2-docker
 Headless JDownloader 2 Docker Container
-This Fork from plusminus/jdownloader2-headless don't use the root User on the Host Volumes.
-The downloads are submitted with the Docker User.
+
+Now it is possible to use a Host Volumes, and this Files are not stored with the root User.
+The downloads are submitted with the User who create/run the Docker Container.
 
 ## Running the container
 0. `sudo su`

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The downloads are submitted with the User who create/run the Docker Container.
 ## Running the container
 0. `sudo su`
 1. Create a folder on your host for the configuration files (eg. sudo mkdir ~/config/jd2)
-2. run `docker run -d --name jd2 -v ~/config/jd2:/opt/JDownloader/cfg -v /home/user/Downloads:/home/jdownloader/Downloads mrbolle/jdownloader2-headless`
+2. run `docker run -d --name jd2 -v ~/config/jd2:/opt/JDownloader/cfg -v /media/Downloads:/home/jdownloader/Downloads plusminus/jdownloader2-headless`
 3. stop the container `docker stop jd2`
-4. On your host, enter your credentials (in quotes) to the file `org.jdownloader.api.myjdownloader.MyJDownloaderSettings.json` as in `{ "password" : "mypasswort", "email" : "email@home.org" }`
+4. On your host, enter your credentials (in quotes) into the config Folder ~/config/jd2 to the new file  `org.jdownloader.api.myjdownloader.MyJDownloaderSettings.json` as in `{ "password" : "mypasswort", "email" : "email@home.org" }`
 5. Start the container `docker start jd2`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # headless-jd2-docker
 Headless JDownloader 2 Docker Container
-The directory is not included as a root user in the host, the downloads are submitted with the Docker User
+This Fork from plusminus/jdownloader2-headless don't use the root User on the Host Volumes.
+The downloads are submitted with the Docker User.
 
 ## Running the container
 0. `sudo su`

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 # headless-jd2-docker
 Headless JDownloader 2 Docker Container
+The directory is not included as a root user in the host, the downloads are submitted with the Docker User
 
 ## Running the container
 0. `sudo su`
-1. Create a folder on your host for the configuration files (eg. sudo mkdir /config/jd2)
-2. run `docker run -d --name jd2 -v /config/jd2:/opt/JDownloader/cfg -v /home/user/Downloads:/root/Downloads plusminus/jdownloader2-headless`
+1. Create a folder on your host for the configuration files (eg. sudo mkdir ~/config/jd2)
+2. run `docker run -d --name jd2 -v ~/config/jd2:/opt/JDownloader/cfg -v /home/user/Downloads:/home/jdownloader/Downloads mr-bolle/headless-jd2-docker`
 3. stop the container `docker stop jd2`
 4. On your host, enter your credentials (in quotes) to the file `org.jdownloader.api.myjdownloader.MyJDownloaderSettings.json` as in `{ "password" : "mypasswort", "email" : "email@home.org" }`
-5. Start the container
-
-
+5. Start the container `docker start jd2`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# headless-jd2-docker
+# headless-jdownloader2-docker
 Headless JDownloader 2 Docker Container
 This Fork from plusminus/jdownloader2-headless don't use the root User on the Host Volumes.
 The downloads are submitted with the Docker User.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The downloads are submitted with the Docker User.
 ## Running the container
 0. `sudo su`
 1. Create a folder on your host for the configuration files (eg. sudo mkdir ~/config/jd2)
-2. run `docker run -d --name jd2 -v ~/config/jd2:/opt/JDownloader/cfg -v /home/user/Downloads:/home/jdownloader/Downloads mr-bolle/headless-jd2-docker`
+2. run `docker run -d --name jd2 -v ~/config/jd2:/opt/JDownloader/cfg -v /home/user/Downloads:/home/jdownloader/Downloads mrbolle/jdownloader2-headless`
 3. stop the container `docker stop jd2`
 4. On your host, enter your credentials (in quotes) to the file `org.jdownloader.api.myjdownloader.MyJDownloaderSettings.json` as in `{ "password" : "mypasswort", "email" : "email@home.org" }`
 5. Start the container `docker start jd2`

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # headless-jdownloader2-docker
 Headless JDownloader 2 Docker Container
 
-Now it is possible to use a Host Volumes, and this Files are not stored with the root User.
+Now it is possible to use a Host Volumes, and this Files are not stored with the root User.<br>
 The downloads are submitted with the User who create/run the Docker Container.
 
 ## Running the container

--- a/startJD2.sh
+++ b/startJD2.sh
@@ -1,17 +1,34 @@
 #!/bin/bash
 
 function stopJD2 {
-	PID=$(cat JDownloader.pid)
-	kill $PID
-	wait $PID
-	exit
+        PID=$(cat JDownloader.pid)
+        kill $PID
+        wait $PID
+        exit
 }
+
+# modification from https://github.com/gotofoo/docker-jdownloader2-headless
+if [ "$GID" ]
+then
+        GROUP=jdownloader
+        groupadd -g $GID $GROUP
+else
+        GROUP=root
+fi
+
+if [ "$UID" ]
+then
+        USER=jdownloader
+        useradd -r -s /bin/false -u $UID -g $GROUP $USER
+        chown -R $USER:$GROUP /opt/JDownloader
+else
+        USER=root
+fi
 
 trap stopJD2 EXIT
 
-java -Djava.awt.headless=true -jar /opt/JDownloader/JDownloader.jar &
+su -c "java -Djava.awt.headless=true -jar /opt/JDownloader/JDownloader.jar" -s /bin/bash $USER
 
 while true; do
-	sleep inf
+        sleep inf
 done
-


### PR DESCRIPTION
Hi PlusMinus0, 

i have found a possibility to don't use the root User into the Host, if you download Files into the JDownloader Container.  Your issue #1 

I create into the Dockerfile a new User and all Downloaded files will be shared with the Host, with the Docker User who run the Container.

Feel free to acept this Pull Request, or you create a new TAG for this Image. And the User can deside to use this.