### PR TITLE
fix somtimes force to jdownloader user

### DIFF
--- a/startJD2.sh
+++ b/startJD2.sh
@@ -7,7 +7,7 @@ function stopJD2 {
 	exit
 }
 
-if [ "$GID" ]
+if [ "$GID" ] && [ "$GID" -ne "0" ]
 then
 	GROUP=jdownloader
 	groupadd -g $GID $GROUP
@@ -15,7 +15,7 @@ else
 	GROUP=root
 fi
 
-if [ "$UID" ] 
+if [ "$UID" ] && [ "$UID" -ne "0" ]
 then
 	USER=jdownloader
 	useradd -r -N -s /bin/false -u $UID $USER


### PR DESCRIPTION
Exemple on synology docker interface, env variable can't be empty and even if i put 0 to UID and GID this script force to "jdownloader" user and after that i've got some error (cannot access to download directory)