### PR TITLE
improve signal handling, alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER PlusMinus <piddlpiddl@gmail.com>
 RUN \
     apk add --no-cache --quiet tini su-exec bash && \
 	mkdir -p /opt/JDownloader/ && \
-	wget -O /opt/JDownloader/JDownloader.jar --user-agent="https://hub.docker.com/r/plusminus/jdownloader2-headless/" --progress=bar:force http://installer.jdownloader.org/JDownloader.jar && \
+	wget -O /opt/JDownloader/JDownloader.jar --user-agent="https://hub.docker.com/r/plusminus/jdownloader2-headless/" http://installer.jdownloader.org/JDownloader.jar && \
 	java -Djava.awt.headless=true -jar /opt/JDownloader/JDownloader.jar
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER PlusMinus <piddlpiddl@gmail.com>
 
 # Create directory, and start JD2 for the initial update and creation of config files.
 RUN \
+    apk add --no-cache --quiet tini su-exec bash && \
 	mkdir -p /opt/JDownloader/ && \
 	wget -O /opt/JDownloader/JDownloader.jar --user-agent="https://hub.docker.com/r/plusminus/jdownloader2-headless/" --progress=bar:force http://installer.jdownloader.org/JDownloader.jar && \
 	java -Djava.awt.headless=true -jar /opt/JDownloader/JDownloader.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM openjdk:8-jre
+FROM openjdk:8-jre-alpine
 
 MAINTAINER PlusMinus <piddlpiddl@gmail.com>
 
 
-# Create directory, downloader JD" and start JD2 for the initial update and creation of config files.
+# Create directory, and start JD2 for the initial update and creation of config files.
 RUN \
 	mkdir -p /opt/JDownloader/ && \
 	wget -O /opt/JDownloader/JDownloader.jar --user-agent="https://hub.docker.com/r/plusminus/jdownloader2-headless/" --progress=bar:force http://installer.jdownloader.org/JDownloader.jar && \
@@ -14,5 +14,6 @@ COPY startJD2.sh /opt/JDownloader/
 RUN chmod +x /opt/JDownloader/startJD2.sh
 
 
+ENTRYPOINT ["/sbin/tini", "-g", "--", "/opt/JDownloader/startJD2.sh"]
 # Run this when the container is started
-CMD /opt/JDownloader/startJD2.sh
+CMD ["java", "-Djava.awt.headless=true", "-jar", "/opt/JDownloader/JDownloader.jar"]

--- a/startJD2.sh
+++ b/startJD2.sh
@@ -19,5 +19,5 @@ fi
 useradd -G $GROUP $USER
 chown -R $USER:$GROUP /opt/JDownloader
 
-exec su-exec "$@"
+exec su-exec ${USER}:${GROUP} "$@"
 

--- a/startJD2.sh
+++ b/startJD2.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 
-function stopJD2 {
-	PID=$(cat JDownloader.pid)
-	kill $PID
-	wait $PID
-	exit
-}
-
 if [ "$GID" ] && [ "$GID" -ne "0" ]
 then
 	GROUP=jdownloader
@@ -26,11 +19,5 @@ fi
 useradd -G $GROUP $USER
 chown -R $USER:$GROUP /opt/JDownloader
 
-trap stopJD2 EXIT
-
-su -c "java -Djava.awt.headless=true -jar /opt/JDownloader/JDownloader.jar &" -s /bin/bash $USER
-
-while true; do
-	sleep inf
-done
+exec su-exec "$@"
 


### PR DESCRIPTION
tini allows proper signal propagation and using exec to replace the shell as the top process tree element we can ensure proper propagation of the signal that is received by the container.

switch to alpine proposed simply because it allows easier install of tini without having to deal with gpg verification intermittent errors