### PR TITLE
Update README.md Setup Download directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
     ```
     docker run -d --name jd2 \
         -v /config/jd2:/opt/JDownloader/cfg \
-        -v /home/user/Downloads:/downloads \
+        -v /home/user/Downloads:/opt/JDownloader/Downloads \
         plusminus/jdownloader2-headless
     ```
 3.  Wait a minute for the container to initialize


### PR DESCRIPTION
For me JDownloader defaults to download to `/opt/JDownloader/Downloads` instead of `/downloads`. So I thought it might be a good idea to reflect that in the example setup.